### PR TITLE
#391 ARM아키텍처 전용 Dockerfile 추가

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,112 @@
+FROM --platform=linux/arm64 debian:trixie-slim AS builder
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+ENV DEBIAN_FRONTEND=noninteractive
+WORKDIR /app
+
+RUN --mount=type=cache,target=/var/cache/apt,id=apt-cahce-1-$TARGETARCH$TARGETVARIANT-builder,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,id=apt-cahce-2-$TARGETARCH$TARGETVARIANT-builder,sharing=locked \
+    <<EOS
+set -ex
+rm -f /etc/apt/apt.conf.d/docker-clean
+echo 'Binary::apt::APT::Keep-Downloaded-Packages "1";' > /etc/apt/apt.conf.d/keep-cache
+echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/no-recommends
+echo 'APT::AutoRemove::RecommendsImportant "0";' >> /etc/apt/apt.conf.d/no-recommends
+apt-get update
+apt-get install -y libtool make cmake libseccomp-dev gcc python3 python3-venv python3-dev
+EOS
+
+COPY Judger/ /app/
+RUN <<EOS
+set -ex
+mkdir /app/build
+cmake -S . -B build
+cmake --build build --parallel $(nproc)
+EOS
+
+RUN <<EOS
+set -ex
+cd bindings/Python
+python3 -m venv .venv
+.venv/bin/pip3 install build
+.venv/bin/python3 -m build -w
+EOS
+
+FROM --platform=linux/arm64 debian:trixie-slim
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV GO_VERSION=1.22.5
+ENV NODE_VERSION=20.12.2
+WORKDIR /app
+
+RUN --mount=type=cache,target=/var/cache/apt,id=apt-cahce-1-$TARGETARCH$TARGETVARIANT-final,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,id=apt-cahce-2-$TARGETARCH$TARGETVARIANT-final,sharing=locked \
+    <<EOS
+set -ex
+rm -f /etc/apt/apt.conf.d/docker-clean
+echo 'Binary::apt::APT::Keep-Downloaded-Packages "1";' > /etc/apt/apt.conf.d/keep-cache
+echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/no-recommends
+echo 'APT::AutoRemove::RecommendsImportant "0";' >> /etc/apt/apt.conf.d/no-recommends
+apt-get update
+apt-get install -y ca-certificates curl wget gnupg gcc-13 g++-13 python3 python3-venv python3-dev openjdk-21-jdk strace xz-utils
+
+cd /tmp
+curl -fsSL https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-arm64.tar.xz -o node.tar.xz
+tar -xJf node.tar.xz -C /usr/local --strip-components=1
+rm -f node.tar.xz
+
+
+cd /tmp
+wget -q https://go.dev/dl/go${GO_VERSION}.linux-arm64.tar.gz
+tar -C /usr/local -xzf go${GO_VERSION}.linux-arm64.tar.gz
+ln -s /usr/local/go/bin/go /usr/bin/go
+rm go${GO_VERSION}.linux-arm64.tar.gz
+
+echo "LS"
+ls -l /usr/bin/gcc-13 /usr/bin/g++-13 /usr/bin/python3
+
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/aarch64-linux-gnu-gcc-13 13
+update-alternatives --install /usr/bin/g++ g++ /usr/bin/aarch64-linux-gnu-g++-13 13
+# update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3 12
+
+# rm -rf /usr/lib/jvm/java-21-openjdk-arm64/lib/src.zip
+EOS
+
+COPY --from=builder --chmod=755 --link /app/output/libjudger.so /usr/lib/judger/libjudger.so
+COPY --from=builder /app/bindings/Python/dist/ /app/
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cahce-$TARGETARCH$TARGETVARIANT-final \
+    <<EOS
+set -ex
+python3 -m venv .venv
+CC=gcc .venv/bin/pip3 install --compile --no-cache-dir flask gunicorn idna psutil requests
+.venv/bin/pip3 install *.whl
+EOS
+
+COPY server/ /app/
+RUN <<EOS
+set -ex
+chmod -R u=rwX,go=rX /app/
+chmod +x /app/entrypoint.sh
+gcc -shared -fPIC -o unbuffer.so unbuffer.c
+useradd -u 901 -r -s /sbin/nologin -M compiler
+useradd -u 902 -r -s /sbin/nologin -M code
+useradd -u 903 -r -s /sbin/nologin -M -G code spj
+mkdir -p /usr/lib/judger
+EOS
+
+RUN <<EOS
+set -ex
+gcc --version
+g++ --version
+python3 --version
+java -version
+node --version
+go version
+EOS
+
+HEALTHCHECK --interval=5s CMD [ "/app/.venv/bin/python3", "/app/service.py" ]
+EXPOSE 8080
+ENTRYPOINT [ "/app/entrypoint.sh" ]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -65,9 +65,6 @@ tar -C /usr/local -xzf go${GO_VERSION}.linux-arm64.tar.gz
 ln -s /usr/local/go/bin/go /usr/bin/go
 rm go${GO_VERSION}.linux-arm64.tar.gz
 
-echo "LS"
-ls -l /usr/bin/gcc-13 /usr/bin/g++-13 /usr/bin/python3
-
 update-alternatives --install /usr/bin/gcc gcc /usr/bin/aarch64-linux-gnu-gcc-13 13
 update-alternatives --install /usr/bin/g++ g++ /usr/bin/aarch64-linux-gnu-g++-13 13
 # update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3 12


### PR DESCRIPTION
# Changelog
- 기존 Dockerfile에서 builder 이미지를 `linux/arm64` 기반 debian으로 변경하였습니다.
- `node`, `go` 를 tarball을 직접 받아 설치하도록 변경하였습니다.
- JVM을 `openjdk-21`로 교체하였습니다.

# Testing
1. Docker ARM 이미지 빌드
```
docker buildx build -f Dockerfile.arm64 --platform linux/arm64 -t myimage:arm64 --load .
```

2. Docker 컨테이너 실행
```
docker run -d \
--name code-place-judge-server \
--read-only \
--tmpfs /tmp \
-v "/Users/junwoo/Documents/code-place/backend/data/test_case:/test_case:ro" \
-v "/Users/junwoo/Documents/code-place/backend/data/judge_server/log:/log" \
-v "/Users/junwoo/Documents/code-place/backend/data/judge_server/run:/judger" \
-e BACKEND_URL=http://host.docker.internal:8000/api/judge_server_heartbeat \
-e SERVICE_URL=http://127.0.0.1:12358 \
-e TOKEN={TOKEN} \
-p 12358:8080 \
code-place-judge-server:arm64
```

3. 결과
<img width="1338" alt="image" src="https://github.com/user-attachments/assets/5249415a-3d81-4557-af61-17313305aa3b" />

<img width="1382" alt="image" src="https://github.com/user-attachments/assets/a210be42-9b0a-461b-add2-23f243ad5ad8" />

# Ops Impact
N/A

# Version Compatibility
N/A