### PR TITLE
#457 부하와 관계없이 일정한 시간 측정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,11 +48,10 @@ rm -f /etc/apt/apt.conf.d/docker-clean
 echo 'Binary::apt::APT::Keep-Downloaded-Packages "1";' > /etc/apt/apt.conf.d/keep-cache
 echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/no-recommends
 echo 'APT::AutoRemove::RecommendsImportant "0";' >> /etc/apt/apt.conf.d/no-recommends
-needed="python3.12-minimal \
-    python3.12-venv \
-    libpython3.12-stdlib \
-    libpython3.12-dev \
-    golang-1.22-go \
+needed="python3 \
+    python3-venv \
+    python3-dev \
+    golang-go \
     temurin-21-jdk \
     gcc-13 \
     g++-13 \
@@ -65,7 +64,7 @@ curl -fsSL https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --
 cat > /etc/apt/sources.list.d/adoptium.sources <<EOF
 Types: deb
 URIs: https://packages.adoptium.net/artifactory/deb
-Suites: bookworm
+Suites: trixie
 Components: main
 Signed-By: /etc/apt/keyrings/adoptium.gpg
 EOF
@@ -81,8 +80,7 @@ apt-get update
 apt-get install -y $needed
 update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 13
 update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 13
-update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 12
-update-alternatives --install /usr/bin/go go /usr/lib/go-1.22/bin/go 22
+
 rm -rf /usr/lib/jvm/temurin-21-jdk-*/jmods
 rm -rf /usr/lib/jvm/temurin-21-jdk-*/lib/src.zip
 apt-mark auto '.*' > /dev/null

--- a/server/utils.py
+++ b/server/utils.py
@@ -1,29 +1,109 @@
-import _judger
 import hashlib
 import logging
 import os
 import socket
 
+import _judger
 import psutil
-
 from config import SERVER_LOG_PATH
 from exception import JudgeClientError
 
 logger = logging.getLogger(__name__)
 handler = logging.FileHandler(SERVER_LOG_PATH)
-formatter = logging.Formatter('%(asctime)s %(levelname)s %(message)s')
+formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
 handler.setFormatter(formatter)
 logger.addHandler(handler)
 logger.setLevel(logging.WARNING)
 
 
+def get_available_cpu_count():
+    """
+    Get the actual available CPU count considering cgroup limits (Docker/Kubernetes).
+    Falls back to psutil.cpu_count() if cgroup info is not available.
+    """
+    try:
+        # Try cgroup v2 first
+        cpu_max_path = "/sys/fs/cgroup/cpu.max"
+        if os.path.exists(cpu_max_path):
+            with open(cpu_max_path, "r") as f:
+                cpu_max = f.read().strip()
+                if cpu_max != "max":
+                    # Format: "quota period" (e.g., "100000 100000" means 1 CPU)
+                    parts = cpu_max.split()
+                    if len(parts) == 2:
+                        quota = int(parts[0])
+                        period = int(parts[1])
+                        if quota > 0 and period > 0:
+                            cpu_count = max(1, int(quota / period))
+                            logger.info(f"Using cgroup v2 CPU count: {cpu_count}")
+                            return cpu_count
+
+        # Try cgroup v1
+        cpu_quota_path = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+        cpu_period_path = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
+
+        if os.path.exists(cpu_quota_path) and os.path.exists(cpu_period_path):
+            with open(cpu_quota_path, "r") as f:
+                quota = int(f.read().strip())
+            with open(cpu_period_path, "r") as f:
+                period = int(f.read().strip())
+
+            if quota > 0 and period > 0:
+                cpu_count = max(1, int(quota / period))
+                logger.info(f"Using cgroup v1 CPU count: {cpu_count}")
+                return cpu_count
+
+        # Try cpuset (cgroup v1/v2)
+        cpuset_paths = [
+            "/sys/fs/cgroup/cpuset.cpus.effective",  # cgroup v2
+            "/sys/fs/cgroup/cpuset/cpuset.cpus",  # cgroup v1
+        ]
+
+        for cpuset_path in cpuset_paths:
+            if os.path.exists(cpuset_path):
+                with open(cpuset_path, "r") as f:
+                    cpus = f.read().strip()
+                    if cpus:
+                        # Parse CPU list (e.g., "0-3", "0,2-4", "1")
+                        cpu_count = len(_parse_cpu_list(cpus))
+                        if cpu_count > 0:
+                            logger.info(f"Using cpuset CPU count: {cpu_count}")
+                            return cpu_count
+
+    except Exception as e:
+        logger.warning(f"Failed to read cgroup CPU info: {e}")
+
+    # Fallback to psutil
+    cpu_count = psutil.cpu_count()
+    logger.info(f"Using psutil CPU count (fallback): {cpu_count}")
+    return cpu_count
+
+
+def _parse_cpu_list(cpu_list_str):
+    """
+    Parse CPU list string like "0-3", "0,2-4", "1" into a set of CPU indices.
+    """
+    cpus = set()
+    for part in cpu_list_str.split(","):
+        if "-" in part:
+            start, end = map(int, part.split("-"))
+            cpus.update(range(start, end + 1))
+        else:
+            cpus.add(int(part))
+    return cpus
+
+
 def server_info():
     ver = _judger.VERSION
-    return {"hostname": socket.gethostname(),
-            "cpu": psutil.cpu_percent(),
-            "cpu_core": psutil.cpu_count(),
-            "memory": psutil.virtual_memory().percent,
-            "judger_version": ".".join([str((ver >> 16) & 0xff), str((ver >> 8) & 0xff), str(ver & 0xff)])}
+    return {
+        "hostname": socket.gethostname(),
+        "cpu": psutil.cpu_percent(),
+        "cpu_core": get_available_cpu_count(),
+        "memory": psutil.virtual_memory().percent,
+        "judger_version": ".".join(
+            [str((ver >> 16) & 0xFF), str((ver >> 8) & 0xFF), str(ver & 0xFF)]
+        ),
+    }
 
 
 def get_token():


### PR DESCRIPTION
# Background
현재 JudgeServer는 docker-compose에 묶여 컨테이너를 생성하고 있습니다. 이 때, docker-compose.yml에는 다음과 같은 CPU, Memory 제한이 있습니다.

```
oj-judge:
    image: registry.code-place-dev.site/code-place-prod/judge-server:1.0.0-beta
    deploy:
      replicas: 6
      update_config:
        parallelism: 2
        order: stop-first
      restart_policy:
        condition: on-failure
      resources:
        limits:
          cpus: "0.50"
          memory: 1GB
        reservations:
          cpus: "0.10"
          memory: 300M
```

하지만 JudgeServer 내부에서 자신의 CPU 코어 수를 측정할 때, `psutil.cpu_count()`를 사용하고 있습니다. 이는 docker-compose에서 제한된 CPU 코어 개수를 반환하는 것이 아닌, 실제 물리 서버의 CPU 코어 개수를 반환하고 있습니다.

따라서 0.5 vCPU로 제한을 둔 경우에도, JudgeServer는 자신이 20 vCPU를 사용할 수 있다고 인식하고 있습니다.

이는 **JudgeServer가 자신의 CPU 사용량에 맞지 않는 과도한 병렬 채점을 발생시키고, 자연스럽게 CPU 경합이 폭발적으로 증가**하여 `real_time`이 매우 커지는 현상이 발생하였습니다.

# Changelog
- JudgeServer가 CPU 코어 개수를 측정할 때, docker-compose에서 제한된 CPU 코어를 인식할 수 있도록 `cgroup`의 정보를 읽어오도록 수정하였습니다.
- `JudgeClient`가 worker pool을 생성할 때, cgroup에서 읽어온 CPU 코어 개수를 기반으로 생성하도록 변경하였습니다.
- Dockerfile이 빌드되지 않는 오류를 수정하였습니다.

# Testing
<img width="4500" height="2100" alt="time_cost" src="https://github.com/user-attachments/assets/7a23d165-d003-4c65-bdd1-9bfb2b2198c8" />

<img width="4200" height="2100" alt="judge_time" src="https://github.com/user-attachments/assets/bc2bb1db-3235-49c7-808a-f400c6405e6d" />

# Ops Impact
N/A

# Version Compatibility
N/A