### PR TITLE
#462 채점 서버 C++ 표준 업그레이드

### DIFF
--- a/client/PHP/languages.php
+++ b/client/PHP/languages.php
@@ -40,7 +40,7 @@ return [
             'max_cpu_time' => 3000,
             'max_real_time' => 5000,
             'max_memory' => 128 * 1024 * 1024,
-            'compile_command' => '/usr/bin/g++ -DONLINE_JUDGE -O2 -w -fmax-errors=3 -std=c++11 {src_path} -lm -o {exe_path}',
+            'compile_command' => '/usr/bin/g++ -DONLINE_JUDGE -O2 -w -fmax-errors=3 -std=c++17 {src_path} -lm -o {exe_path}',
         ],
         'run' => [
             'command' => '{exe_path}',

--- a/client/Python/languages.py
+++ b/client/Python/languages.py
@@ -13,11 +13,7 @@ c_lang_config = {
         "max_memory": 128 * 1024 * 1024,
         "compile_command": "/usr/bin/gcc -DONLINE_JUDGE -O2 -w -fmax-errors=3 -std=c99 {src_path} -lm -o {exe_path}",
     },
-    "run": {
-        "command": "{exe_path}",
-        "seccomp_rule": "c_cpp",
-        "env": default_env
-    }
+    "run": {"command": "{exe_path}", "seccomp_rule": "c_cpp", "env": default_env},
 }
 
 c_lang_spj_compile = {
@@ -26,13 +22,13 @@ c_lang_spj_compile = {
     "max_cpu_time": 3000,
     "max_real_time": 5000,
     "max_memory": 1024 * 1024 * 1024,
-    "compile_command": "/usr/bin/gcc -DONLINE_JUDGE -O2 -w -fmax-errors=3 -std=c99 {src_path} -lm -o {exe_path}"
+    "compile_command": "/usr/bin/gcc -DONLINE_JUDGE -O2 -w -fmax-errors=3 -std=c99 {src_path} -lm -o {exe_path}",
 }
 
 c_lang_spj_config = {
     "exe_name": "spj-{spj_version}",
     "command": "{exe_path} {in_file_path} {user_out_file_path}",
-    "seccomp_rule": "c_cpp"
+    "seccomp_rule": "c_cpp",
 }
 
 cpp_lang_config = {
@@ -42,13 +38,9 @@ cpp_lang_config = {
         "max_cpu_time": 3000,
         "max_real_time": 5000,
         "max_memory": 128 * 1024 * 1024,
-        "compile_command": "/usr/bin/g++ -DONLINE_JUDGE -O2 -w -fmax-errors=3 -std=c++11 {src_path} -lm -o {exe_path}",
+        "compile_command": "/usr/bin/g++ -DONLINE_JUDGE -O2 -w -fmax-errors=3 -std=c++17 {src_path} -lm -o {exe_path}",
     },
-    "run": {
-        "command": "{exe_path}",
-        "seccomp_rule": "c_cpp",
-        "env": default_env
-    }
+    "run": {"command": "{exe_path}", "seccomp_rule": "c_cpp", "env": default_env},
 }
 
 java_lang_config = {
@@ -59,14 +51,14 @@ java_lang_config = {
         "max_cpu_time": 3000,
         "max_real_time": 5000,
         "max_memory": -1,
-        "compile_command": "/usr/bin/javac {src_path} -d {exe_dir} -encoding UTF8"
+        "compile_command": "/usr/bin/javac {src_path} -d {exe_dir} -encoding UTF8",
     },
     "run": {
         "command": "/usr/bin/java -cp {exe_dir} -XX:MaxRAM={max_memory}k -Djava.security.manager -Dfile.encoding=UTF-8 -Djava.security.policy==/etc/java_policy -Djava.awt.headless=true Main",
         "seccomp_rule": None,
         "env": default_env,
-        "memory_limit_check_only": 1
-    }
+        "memory_limit_check_only": 1,
+    },
 }
 
 
@@ -82,8 +74,8 @@ py2_lang_config = {
     "run": {
         "command": "/usr/bin/python {exe_path}",
         "seccomp_rule": "general",
-        "env": default_env
-    }
+        "env": default_env,
+    },
 }
 
 py3_lang_config = {
@@ -98,8 +90,8 @@ py3_lang_config = {
     "run": {
         "command": "/usr/bin/python3 {exe_path}",
         "seccomp_rule": "general",
-        "env": ["PYTHONIOENCODING=UTF-8"] + default_env
-    }
+        "env": ["PYTHONIOENCODING=UTF-8"] + default_env,
+    },
 }
 
 go_lang_config = {
@@ -110,15 +102,15 @@ go_lang_config = {
         "max_real_time": 5000,
         "max_memory": 1024 * 1024 * 1024,
         "compile_command": "/usr/bin/go build -o {exe_path} {src_path}",
-        "env": ["GOCACHE=/tmp", "GOPATH=/tmp/go"]
+        "env": ["GOCACHE=/tmp", "GOPATH=/tmp/go"],
     },
     "run": {
         "command": "{exe_path}",
         "seccomp_rule": "",
         # 降低内存占用
         "env": ["GODEBUG=madvdontneed=1", "GOCACHE=off"] + default_env,
-        "memory_limit_check_only": 1
-    }
+        "memory_limit_check_only": 1,
+    },
 }
 
 php_lang_config = {
@@ -127,7 +119,7 @@ php_lang_config = {
         "command": "/usr/bin/php {exe_path}",
         "seccomp_rule": "",
         "env": default_env,
-        "memory_limit_check_only": 1
+        "memory_limit_check_only": 1,
     }
 }
 
@@ -137,6 +129,6 @@ js_lang_config = {
         "command": "/usr/bin/node {exe_path}",
         "seccomp_rule": "",
         "env": ["NO_COLOR=true"] + default_env,
-        "memory_limit_check_only": 1
+        "memory_limit_check_only": 1,
     }
 }

--- a/client/go/languages.go
+++ b/client/go/languages.go
@@ -67,7 +67,7 @@ var CPPLangConfig = &LangConfig{
 		MaxCpuTime:     3000,
 		MaxRealTime:    5000,
 		MaxMemory:      128 * 1024 * 1024,
-		CompileCommand: "/usr/bin/g++ -DONLINE_JUDGE -O2 -w -fmax-errors=3 -std=c++11 {src_path} -lm -o {exe_path}",
+		CompileCommand: "/usr/bin/g++ -DONLINE_JUDGE -O2 -w -fmax-errors=3 -std=c++17 {src_path} -lm -o {exe_path}",
 	},
 	RunConfig: RunConfig{
 		Command:     "{exe_path}",


### PR DESCRIPTION
# Changelog
- 채점 서버가 C++ 컴파일 시 `C++11` 에서 `C++17` 표준으로 업그레이드하였습니다.

# Testing
- `C++17`부터 사용 가능한 **구조적 바인딩 기능 사용** 후 컴파일 에러 여부 확인
<img width="815" height="756" alt="image" src="https://github.com/user-attachments/assets/aaa5474d-d6fd-444c-ba26-c2c97c49ef3f" />

# Ops Impact
N/A

# Version Compatibility
N/A