### PR TITLE
#525 Cgroup에 따른 워커 개수 조정

### DIFF
--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -10,11 +10,35 @@ chmod 711 /judger/run
 chown compiler:spj /judger/spj
 chmod 710 /judger/spj
 
-CPU_CORE_NUM="$(nproc)"
-if [ "$CPU_CORE_NUM" -lt 2 ]; then
-    export WORKER_NUM=2;
-else
-    export WORKER_NUM="$CPU_CORE_NUM";
+DEFAULT_WORKER_NUM=4
+
+# 워커 수가 지정되지 않은 경우 cgroup 제한에 따라 자동으로 설정
+if [ -z "$WORKER_NUM" ]; then
+    # cgroup v2
+    if [ -f "/sys/fs/cgroup/cpu.max" ]; then
+        CPU_MAX=$(cat /sys/fs/cgroup/cpu.max)
+        if [ "$CPU_MAX" != "max" ]; then
+            CPU_QUOTA=$(echo "$CPU_MAX" | cut -d' ' -f1)
+            CPU_PERIOD=$(echo "$CPU_MAX" | cut -d' ' -f2)
+
+            if [ -n "$CPU_QUOTA" ] && [ -n "$CPU_PERIOD" ] && [ "$CPU_PERIOD" -gt 0 ]; then
+                WORKER_NUM=$((CPU_QUOTA / CPU_PERIOD))
+            fi
+        fi
+    # cgroup v1
+    elif [ -f "/sys/fs/cgroup/cpu/cpu.cfs_quota_us" ] && [ -f "/sys/fs/cgroup/cpu/cpu.cfs_period_us" ]; then
+        CPU_QUOTA=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
+        CPU_PERIOD=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us)
+
+        if [ "$CPU_QUOTA" -gt 0 ] && [ "$CPU_PERIOD" -gt 0 ]; then
+            WORKER_NUM=$((CPU_QUOTA / CPU_PERIOD))
+        fi
+    fi
+
+    # cgroup에서 워커 수를 가져오지 못한 경우 기본값을 사용
+    if [ -z "$WORKER_NUM" ] || [ "$WORKER_NUM" -eq 0 ]; then
+        export WORKER_NUM=${DEFAULT_WORKER_NUM}
+    fi
 fi
 
 exec .venv/bin/gunicorn server:app --workers $WORKER_NUM --threads 4 --error-logfile /log/gunicorn.log --bind 0.0.0.0:8080

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -22,7 +22,7 @@ if [ -z "$WORKER_NUM" ]; then
             CPU_PERIOD=$(echo "$CPU_MAX" | cut -d' ' -f2)
 
             if [ -n "$CPU_QUOTA" ] && [ -n "$CPU_PERIOD" ] && [ "$CPU_PERIOD" -gt 0 ]; then
-                WORKER_NUM=$((CPU_QUOTA / CPU_PERIOD))
+                export WORKER_NUM=$((CPU_QUOTA / CPU_PERIOD))
             fi
         fi
     # cgroup v1
@@ -31,7 +31,7 @@ if [ -z "$WORKER_NUM" ]; then
         CPU_PERIOD=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us)
 
         if [ "$CPU_QUOTA" -gt 0 ] && [ "$CPU_PERIOD" -gt 0 ]; then
-            WORKER_NUM=$((CPU_QUOTA / CPU_PERIOD))
+            export WORKER_NUM=$((CPU_QUOTA / CPU_PERIOD))
         fi
     fi
 


### PR DESCRIPTION
## Changelog
-`gunicorn` 워커 생성 시 `nproc`을 읽는 것이 아닌 `cgroup`의 CPU 자원 정보를 읽어 적절한 워커를 생성하도록 변경하였습니다.
- 버전 1.0.3 으로 Harbor Registry에 푸시하였습니다.

## Testing
- 채점 서버 실행 테스트
```bash
$ k logs -f pod/judge-server-788db855bf-mc9ww -n code-place-dev
+ rm -rf /judger/*
+ mkdir -p /judger/run /judger/spj
+ chown compiler:code /judger/run
+ chmod 711 /judger/run
+ chown compiler:spj /judger/spj
+ chmod 710 /judger/spj
+ DEFAULT_WORKER_NUM=4
+ [ -z  ]
+ [ -f /sys/fs/cgroup/cpu.max ]
+ cat /sys/fs/cgroup/cpu.max
+ CPU_MAX=100000 100000
+ [ 100000 100000 != max ]
+ echo 100000 100000
+ cut -d  -f1
+ CPU_QUOTA=100000
+ echo 100000 100000
+ cut -d  -f2
+ CPU_PERIOD=100000
+ [ -n 100000 ]
+ [ -n 100000 ]
+ [ 100000 -gt 0 ]
+ export WORKER_NUM=1
+ [ -z 1 ]
+ [ 1 -eq 0 ]
+ exec .venv/bin/gunicorn server:app --workers 1 --threads 4 --error-logfile /log/gunicorn.log --bind 0.0.0.0:8080
```

## Ops Impact
N/A

## Version Compatibility
N/A